### PR TITLE
docs: fix example `uses:` reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ jobs:
         run: |
           echo "::set-output name=approval::true"
           echo "::set-output name=message::This pull request looks good."
-      - uses: ./
+      - uses: pwei1018/bcrs-ci-action@v1.0.1
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
           pr-approval: "${{ steps.pr.outputs.approval }}"


### PR DESCRIPTION
The local uses reference will only work if people for your repository which is very unlikely if they want to use your action.